### PR TITLE
fix: supra logo in trusted by section

### DIFF
--- a/src/app/styles/home.css
+++ b/src/app/styles/home.css
@@ -1016,8 +1016,12 @@
                   @apply h-full rounded-md;
 
                   & .slide-item-logo {
-                    @apply relative flex justify-start;
+                    @apply relative flex items-center justify-start;
                     @apply h-10;
+
+                    & > img {
+                      @apply block;
+                    }
                   }
 
                   & .slide-item-message {


### PR DESCRIPTION
## Current Behavior
- Image inside class `slide-item-logo` get `display: flex` from `slide-item-logo`, resulting in stretched image 

## New Behavior
- Image inside class `slide-item-logo` get `display: block`

## Notes
- To test this behavior, use `pnpm build && pnpm preview`